### PR TITLE
week8 シャッフルを実装

### DIFF
--- a/src/js/quiz.js
+++ b/src/js/quiz.js
@@ -93,7 +93,35 @@ const createQuiz = ({ num, title, img, choices, ans, src }) => {
     return quizEl;
 }
 
+/**
+ * シャッフルされた配列を生成
+ * @param {array} originalArray 元となる配列
+ * @returns {array} シャッフルされた配列
+ */
+const generateShuffledArray = (originalArray) => {
+    const array = [...originalArray];
+    const newArray = [];
+    while (array.length > 0) {
+        const n = array.length;
+        const k = Math.floor(Math.random() * n);
+
+        newArray.push(array[k]);
+        array.splice(k, 1);
+    }
+    return newArray;
+}
+
+/**
+ * 問題の順番と選択肢の順番をシャッフルしたクイズデータ
+ * @type {Quiz[]}
+ */
+const shuffledQuizzes = generateShuffledArray(quizzes).map((quiz, index) => {
+    quiz.num = index + 1;
+    quiz.choices = generateShuffledArray(quiz.choices);
+    return quiz;
+});
+
 // quizzes配列の中身からクイズを生成して表示
-quizzes.forEach((quiz) => {
+shuffledQuizzes.forEach((quiz) => {
     document.getElementById('quizArea').insertAdjacentElement('beforeend', createQuiz(quiz));
 });


### PR DESCRIPTION
## 今週の課題

- [x] 設問数を増やす場合でもhtmlファイル、cssファイルの修正が不要な作りになっていますか？
- [x] →css,htmlを触らずにjsだけで、設問数を増やせる仕様になっていますか？
- [x] Figmaと比べてサイズや幅の違いはありませんか？
- [x] ページをリロードすると問題と選択肢の順番が変わりますか？
- [x] GitHubにプルリクできましたか？

## 注意点やレビュワーに伝えたいこと(あれば)

## 課題が終わっている証跡(スクショ)
<img width="1800" alt="スクリーンショット 2022-09-20 20 12 51" src="https://user-images.githubusercontent.com/59753159/191243716-12d80069-25a8-4ab2-ba56-7d96d85ce1bc.png">
<img width="1800" alt="スクリーンショット 2022-09-20 20 13 02" src="https://user-images.githubusercontent.com/59753159/191243727-7d628202-766a-4b93-934a-c490aa597489.png">
<img width="1800" alt="スクリーンショット 2022-09-20 20 13 16" src="https://user-images.githubusercontent.com/59753159/191243729-7eed2303-ff2c-4f96-99e1-c7011d6f9bec.png">
<img width="1800" alt="スクリーンショット 2022-09-20 20 13 45" src="https://user-images.githubusercontent.com/59753159/191243735-b78a8d48-a017-4928-8a85-c9c541e65ccc.png">

